### PR TITLE
chore: remove unused eslint disable line

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,4 +8,4 @@ export * from "./lib/config.js";
 import { Dub } from "./sdk/index.js";
 
 /** @deprecated Use named export instead: `import { Dub } from "dub";` */
-export default Dub; // eslint-disable-line import/no-default-export
+export default Dub;


### PR DESCRIPTION
Speakeasy now uses ESLint 9 and with it dropped eslint-plugin-import. `eslint-disable-line` directive was causing a build error because it was unused as result.