### PR TITLE
chore: disable MCP server generation

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -35,7 +35,7 @@ typescript:
   constFieldsAlwaysOptional: true
   defaultErrorName: SDKError
   enableCustomCodeRegions: false
-  enableMCPServer: true
+  enableMCPServer: false
   enableReactQuery: false
   enumFormat: union
   flattenGlobalSecurity: true


### PR DESCRIPTION
- Disabling MCP server generation in TS SDK in favor of hosted server at [mcp.dub.sh/mcp/dub-links](mcp.dub.sh/mcp/dub-links)