### PR TITLE
Add package license metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "dub",
   "version": "0.72.1",
   "author": "Dub",
+  "license": "MIT",
   "type": "module",
   "tshy": {
     "sourceDialects": [


### PR DESCRIPTION
## Summary

- add MIT license metadata to the package manifest
- align npm metadata with the repository license

## Verification

- `npm view dub@latest name version license repository homepage bugs --json`
- `node -e "const p=require('./package.json'); if (p.license !== 'MIT') throw new Error('license mismatch'); console.log(p.name, p.version, p.license)"`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project license to MIT.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->